### PR TITLE
Do not specify "./" as the path on the server

### DIFF
--- a/docs/basics/download_nwb.ipynb
+++ b/docs/basics/download_nwb.ipynb
@@ -173,7 +173,7 @@
    ],
    "source": [
     "# patience isn't just a virtue, it's a requirement\n",
-    "my_dandiset.download_directory(\"./\", f\"{download_loc}/{dandiset_id}\")\n",
+    "my_dandiset.download_directory(\"\", f\"{download_loc}/{dandiset_id}\")\n",
     "\n",
     "print(f\"Downloaded directory to {download_loc}/{dandiset_id}\")"
    ]


### PR DESCRIPTION
If worked before, it stopped working at some point. We are likely to make it more robust on dandi-cli side:
- https://github.com/dandi/dandi-cli/pull/1454

but I think it would be better to just not specify such way in the example. You might want to elaborate that example with actually pointing to a specific folder instead