### PR TITLE
Make contributor records to be hyperlink if email or URL

### DIFF
--- a/databook_utils/insert_authors_version.py
+++ b/databook_utils/insert_authors_version.py
@@ -133,7 +133,16 @@ class AuthorsIndex(Directive):
 
 			line_block = nodes.line_block()				
 			for property in properties[1:]:
-				if property != "":
+				if not property:
+					continue
+				elif property.startswith("https://") or property.startswith("http://"):
+					link_node = nodes.reference(text=property, refuri=property)
+					line_block.append(link_node)
+				elif "@" in property:
+					mailto_link = f"mailto:{property}"
+					email_node = nodes.reference(text=property, refuri=mailto_link)
+					line_block.append(email_node)
+				else:
 					line_block.append(nodes.line(text=property))
 			line_block.append(nodes.line(text=""))
 


### PR DESCRIPTION
email matching is quite rudimentary but I think should work here.

Note: did not test if works, mostly chatgpt creation ;-)  

NB didn't test since on a quick try failed to install local env for the project with python 3.12

NB2 script is using tabs for indentation... caused some surprise and necessity to redo some indentations.