### PR TITLE
Remove extra comma in `contributors.csv`

### DIFF
--- a/data/contributors.csv
+++ b/data/contributors.csv
@@ -25,7 +25,7 @@ Chinmay Purandare,0000-0001-9225-0186,University of California San Francisco,chi
 Pamela Reinagel,0000-0002-6338-2611,University of California San Diego,preinagel@ucsd.edu,,,"Conceptualization, Processing"
 Hyeyoung Shin,,Seoul National University,shinehyeyoung@gmail.com,https://github.com/hs13,,"Conceptualization"
 Josh Siegle,,Allen Institute,joshs@alleninstitute.org,https://github.com/jsiegle,NIH U24,"Processing"
-Jiatai Song,0009-0004-4910-1141,Tsingua University,,https://github.com/Laohusong,,"Processing,Review",
+Jiatai Song,0009-0004-4910-1141,Tsingua University,,https://github.com/Laohusong,,"Processing,Review"
 Shih-Yi Tseng,0000-0002-5029-433X,"University of California, San Francisco",shihyitseng41@gmail.com,https://github.com/sytseng,,"Processing"
 Jacob Westerberg,0000-0001-5331-8707,Netherlands Institute for Neuroscience,j.westerberg@nin.knaw.nl,https://github.com/jakewesterberg,,"Conceptualization"
 Alex Williams,0000-0001-5853-103X,New York University,alex.h.williams@nyu.edu,https://github.com/ahwillia,,"Review"


### PR DESCRIPTION
The proposed change is based off of an error message on GitHub:

![image](https://github.com/user-attachments/assets/931d839c-ef31-421b-adce-bc40f30fb2dc)
